### PR TITLE
compatibility update, port data load code to tf.data, etc.

### DIFF
--- a/datagenerator.py
+++ b/datagenerator.py
@@ -7,7 +7,7 @@
 import tensorflow as tf
 import numpy as np
 
-from tensorflow.contrib.data import Dataset
+from tensorflow.data import Dataset
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework.ops import convert_to_tensor
 
@@ -67,12 +67,14 @@ class ImageDataGenerator(object):
 
         # distinguish between train/infer. when calling the parsing functions
         if mode == 'training':
-            data = data.map(self._parse_function_train, num_threads=8,
-                      output_buffer_size=100*batch_size)
+            data = data.map(
+                self._parse_function_train,
+                num_parallel_calls=8).prefetch(100 * batch_size)
 
         elif mode == 'inference':
-            data = data.map(self._parse_function_inference, num_threads=8,
-                      output_buffer_size=100*batch_size)
+            data = data.map(
+                self._parse_function_inference,
+                num_parallel_calls=8).prefetch(100 * batch_size)
 
         else:
             raise ValueError("Invalid mode '%s'." % (mode))

--- a/finetune.py
+++ b/finetune.py
@@ -20,7 +20,7 @@ import tensorflow as tf
 from alexnet import AlexNet
 from datagenerator import ImageDataGenerator
 from datetime import datetime
-from tensorflow.contrib.data import Iterator
+from tensorflow.data import Iterator
 
 """
 Configuration Part.
@@ -93,7 +93,7 @@ var_list = [v for v in tf.trainable_variables() if v.name.split('/')[0] in train
 
 # Op for calculating the loss
 with tf.name_scope("cross_ent"):
-    loss = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits(logits=score,
+    loss = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits_v2(logits=score,
                                                                   labels=y))
 
 # Train op


### PR DESCRIPTION
minor changes to make this repo be compatible with tf 1.10.

1. port data load code to tf.data, <https://github.com/tensorflow/tensorflow/blob/r1.4/tensorflow/contrib/data/README.md>
2. remove warning, "softmax_cross_entropy_with_logits deprecated", <https://github.com/tensorflow/minigo/issues/37>